### PR TITLE
Allows mods to look at other specific user's highlights

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -49,7 +49,7 @@ pub async fn mute_check(ctx: &client::Context, msg: &Message) -> Result<(), Reas
     check_role(&ctx, msg, config.role_mute).await
 }
 
-async fn check_role(ctx: &client::Context, msg: &Message, role: RoleId) -> Result<(), Reason> {
+pub async fn check_role(ctx: &client::Context, msg: &Message, role: RoleId) -> Result<(), Reason> {
     match msg.guild_id {
         Some(guild_id) => match msg.author.has_role(&ctx, guild_id, role).await {
             Ok(true) => Ok(()),

--- a/src/events/message_create.rs
+++ b/src/events/message_create.rs
@@ -93,7 +93,7 @@ async fn handle_highlighting(ctx: &client::Context, msg: &Message) -> Result<()>
                 "`{}` has been mentioned in {}
                 [link to message]({})
 
-                Don't care about this anymore? 
+                Don't care about this anymore?
                 Run `!highlights remove {}` in #bot to stop getting these notifications.",
                 word,
                 msg.channel_id.mention(),
@@ -108,7 +108,15 @@ async fn handle_highlighting(ctx: &client::Context, msg: &Message) -> Result<()>
             .footer(|f| f.text(format!("#{}", channel.name)));
 
         for user_id in users {
-            if user_id == msg.author.id || handled_users.contains(&user_id) {
+            dbg!(&user_id);
+            let user_can_see_channel = channel
+                .permissions_for_user(&ctx, user_id)
+                .await?
+                .read_messages();
+
+            dbg!(&user_can_see_channel);
+            if user_id == msg.author.id || handled_users.contains(&user_id) || !user_can_see_channel
+            {
                 continue;
             }
             handled_users.insert(user_id);


### PR DESCRIPTION
If the user isn't a mod, and he still supplies an argument, it'll just be ignored. 
I added names to all operations with highlights that could either refer to another user or to yourself, to avoid confusion for the mods. And make it easier to see for normal users what's happening.  

Partly fixes #159