### PR TITLE
change fetch fields to enum, add aliases

### DIFF
--- a/src/commands/fetch/mod.rs
+++ b/src/commands/fetch/mod.rs
@@ -9,9 +9,9 @@ use std::fmt;
 
 /// convert the field-value into the desired format.
 /// Returns `None` if the string is empty, as empty values must not be included in embeds.
-pub fn format_fetch_field_value(field_name: FetchField, value: String) -> Option<String> {
+pub fn format_fetch_field_value(field_name: &FetchField, value: String) -> Option<String> {
     if !value.is_empty() {
-        if field_name == FetchField::Memory {
+        if *field_name == FetchField::Memory {
             if value == "0" {
                 None
             } else {

--- a/src/commands/fetch/setfetch.rs
+++ b/src/commands/fetch/setfetch.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::extensions::StrExt;
 use std::collections::HashMap;
+use std::str::FromStr;
 
 const SETFETCH_USAGE: &str = indoc::indoc!("
     Run this: 
@@ -61,7 +62,7 @@ async fn do_set_fetch(
     let image_url: Option<String> = msg.find_image_urls().first().cloned();
 
     if let Some(image) = image_url {
-        info.insert(IMAGE_KEY.to_string(), image);
+        info.insert(FetchField::Image, image);
     }
 
     if update {
@@ -91,25 +92,31 @@ fn parse_setfetch(lines: Vec<&str>) -> Result<HashMap<String, String>> {
 }
 
 /// Sanitize field values and check validity of user-provided fetch data.
-fn sanitize_fetch(mut fetch: HashMap<String, String>) -> Result<HashMap<String, String>, UserErr> {
+fn sanitize_fetch(
+    mut fetch: HashMap<String, String>,
+) -> Result<HashMap<FetchField, String>, UserErr> {
+    let mut new: HashMap<FetchField, String> = HashMap::new();
     for (key, value) in fetch.iter_mut() {
-        if !NORMAL_FETCH_KEYS.contains(&key.as_ref()) {
+        let field = FetchField::from_str(key);
+        if field.is_err() {
             abort_with!(UserErr::Other(format!("Illegal fetch field: {}", key)))
         }
-        match key.as_str() {
-            MEMORY_KEY => {
+        let field = field.unwrap();
+        match field {
+            FetchField::Memory => {
                 *value = byte_unit::Byte::from_str(&value)
                     .user_error("Malformed value provided for Memory")?
                     .get_bytes()
                     .to_string()
             }
-            IMAGE_KEY => {
+            FetchField::Image => {
                 if !util::validate_url(&value) {
-                    abort_with!("Got malformed url for Image")
+                    abort_with!("Malformed url provided for Image")
                 }
             }
             _ => {}
         }
+        new.insert(field, value.to_string());
     }
-    Ok(fetch)
+    Ok(new)
 }

--- a/src/commands/top.rs
+++ b/src/commands/top.rs
@@ -20,7 +20,7 @@ pub async fn top(ctx: &client::Context, msg: &Message, mut args: Args) -> Comman
 
     let fetches = db.get_all_fetches().await?;
 
-    if args.len() != 0 {
+    if !args.is_empty() {
         let field_name = args
             .single_quoted::<FetchField>()
             .user_error("Not a valid field.")?;

--- a/src/commands/top.rs
+++ b/src/commands/top.rs
@@ -88,7 +88,7 @@ async fn top_for_field(
         .into_iter()
         .filter_map(|mut x| x.info.remove(&field_name))
         .filter(|x| !x.is_empty() && x != "0")
-        .filter_map(|value| format_fetch_field_value(field_name.clone(), value))
+        .filter_map(|value| format_fetch_field_value(&field_name, value))
         .map(|value| canonicalize_top_value(&value));
 
     // only compare the first word when looking at distros
@@ -153,7 +153,7 @@ async fn top_all_values(
             .into_iter()
             .max_by_key(|(_, cnt)| *cnt)?;
 
-        let most_popular_value = format_fetch_field_value(field_name.clone(), most_popular_value)?;
+        let most_popular_value = format_fetch_field_value(&field_name, most_popular_value)?;
 
         Some((
             field_name,

--- a/src/events/message_create.rs
+++ b/src/events/message_create.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use crate::attachment_logging;
+use crate::commands::fetch::FetchField;
 use crate::log_error;
 use chrono::Utc;
 use itertools::Itertools;
@@ -363,8 +364,9 @@ async fn handle_showcase_post(ctx: &client::Context, msg: &Message) -> Result<()
                 let db = ctx.get_db().await;
                 db.update_fetch(
                     msg.author.id,
-                    hashmap! { crate::commands::fetch::IMAGE_KEY.to_string() => attachment.url.to_string() },
-                ).await?;
+                    hashmap! { FetchField::Image => attachment.url.to_string() },
+                )
+                .await?;
             }
         }
     }


### PR DESCRIPTION
* internally use an enum for fetch fields
* add fetch field aliases

Sorry I took so long on this! I implemented `FromString` for the new `FetchField` enum so it can be used with serenity's `Args::single_quoted()` as well as include aliases for different field names. Multiword field names don't seem to work just because of serenity's args thing though; let me know if there's a way to work around this (or anything else I need to fix/clean up/etc) and I'll gladly add it.