### PR TITLE
Now robbb shouldn't yell at us for creating new threads under #showcase posts.

### DIFF
--- a/src/events/message_create.rs
+++ b/src/events/message_create.rs
@@ -343,7 +343,10 @@ async fn handle_spam_protect(ctx: &client::Context, msg: &Message) -> Result<boo
 }
 
 async fn handle_showcase_post(ctx: &client::Context, msg: &Message) -> Result<()> {
-    if msg.attachments.is_empty() && msg.embeds.is_empty() && !msg.content.contains("http") {
+    if msg.attachments.is_empty()
+        && msg.embeds.is_empty()
+        && !msg.content.contains("http")
+        && msg.kind != MessageType::ThreadCreated {
         msg.delete(&ctx)
             .await
             .context("Failed to delete invalid showcase submission")?;


### PR DESCRIPTION
Added check whether the message is a thread using `msg.kind` and the `MessageType` enum.

Robbb should now not warn everybody who creates a thread. Did some extra formatting because the line of the if statement would be too long. 