### PR TITLE
Improve error handling in gen-env.sh

### DIFF
--- a/gen-env.sh
+++ b/gen-env.sh
@@ -13,7 +13,7 @@
 serverid=SERVERIDGOESHERE
 
 
-[ "$token" ] && [ "$serverid" ] || exec \
+[ "${#token}" -ge 50 ] && [ "$serverid" -ge 999 ] || exec \
 	echo "Please add the bot's token and the server's ID to the script"
 
 # clean the env


### PR DESCRIPTION
If you left the script as is, it would not say "please fill in your token & serverid"

Instead of checking for an empty variable,
check the length of the token (>= 50char)
and check if serverid is a number (>= 999)