### PR TITLE
Use server specific profile picture in pfp command

### DIFF
--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,6 +1,6 @@
 use serenity::framework::standard::{Check, Command};
 
-use crate::embeds::PaginatedFieldsEmbed;
+use crate::embeds::PaginatedEmbed;
 
 use super::*;
 
@@ -111,12 +111,12 @@ async fn reply_help_full(
         (name, description)
     });
 
-    PaginatedFieldsEmbed::create(&ctx, fields, |e| {
-        e.title("Help");
-    })
-    .await
-    .reply_to(&ctx, &msg)
-    .await
+    let mut base_embed = embeds::basic_create_embed(ctx).await;
+    base_embed.title("Help");
+    PaginatedEmbed::create_from_fields(fields, base_embed)
+        .await
+        .reply_to(&ctx, &msg)
+        .await
 }
 
 async fn passes_all_checks(

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -111,12 +111,13 @@ async fn reply_help_full(
         (name, description)
     });
 
-    let mut base_embed = embeds::basic_create_embed(ctx).await;
-    base_embed.title("Help");
-    PaginatedEmbed::create_from_fields(fields, base_embed)
-        .await
-        .reply_to(&ctx, &msg)
-        .await
+    PaginatedEmbed::create_from_fields(
+        fields,
+        embeds::make_create_embed(ctx, |e| e.title("Help")).await,
+    )
+    .await
+    .reply_to(&ctx, &msg)
+    .await
 }
 
 async fn passes_all_checks(

--- a/src/commands/move_users.rs
+++ b/src/commands/move_users.rs
@@ -1,4 +1,4 @@
-use crate::embeds::basic_create_embed;
+use crate::embeds::make_create_embed;
 use crate::extensions::ChannelIdExt;
 
 use super::*;
@@ -23,18 +23,16 @@ pub async fn move_users(ctx: &client::Context, msg: &Message, mut args: Args) ->
         .filter_map(|x| Some(x.ok()?.mention()))
         .join(" ");
 
-    let create_embed = {
-        let mut e = basic_create_embed(&ctx).await;
-
+    let create_embed = make_create_embed(&ctx, |e| {
         e.author(|a| a.name(format!("Moved by {}", msg.author.tag())));
         e.description(indoc::formatdoc!(
             "Continuation from {}
                     [Conversation]({})",
             msg.channel_id.mention(),
             msg.link()
-        ));
-        e
-    };
+        ))
+    })
+    .await;
 
     let mut continuation_msg = channel
         .send_message(&ctx, |m| m.content(mentions).set_embed(create_embed))

--- a/src/commands/note.rs
+++ b/src/commands/note.rs
@@ -92,17 +92,19 @@ pub async fn notes(ctx: &client::Context, msg: &Message, mut args: Args) -> Comm
         )
     });
 
-    embeds::PaginatedFieldsEmbed::create(&ctx, fields, |e| {
-        e.title("Notes");
-        e.description(format!("Notes about {}", mentioned_user_id.mention()));
-        e.author(|a| {
+    let mut base_embed = embeds::basic_create_embed(ctx).await;
+    base_embed
+        .title("Notes")
+        .description(format!("Notes about {}", mentioned_user_id.mention()))
+        .author(|a| {
             avatar_url.map(|url| a.icon_url(url));
             a
         });
-    })
-    .await
-    .reply_to(&ctx, &msg)
-    .await?;
+
+    embeds::PaginatedEmbed::create_from_fields(fields, base_embed)
+        .await
+        .reply_to(&ctx, &msg)
+        .await?;
 
     Ok(())
 }

--- a/src/commands/note.rs
+++ b/src/commands/note.rs
@@ -92,14 +92,15 @@ pub async fn notes(ctx: &client::Context, msg: &Message, mut args: Args) -> Comm
         )
     });
 
-    let mut base_embed = embeds::basic_create_embed(ctx).await;
-    base_embed
-        .title("Notes")
-        .description(format!("Notes about {}", mentioned_user_id.mention()))
-        .author(|a| {
-            avatar_url.map(|url| a.icon_url(url));
-            a
-        });
+    let base_embed = embeds::make_create_embed(ctx, |e| {
+        e.title("Notes")
+            .description(format!("Notes about {}", mentioned_user_id.mention()))
+            .author(|a| {
+                avatar_url.map(|url| a.icon_url(url));
+                a
+            })
+    })
+    .await;
 
     embeds::PaginatedEmbed::create_from_fields(fields, base_embed)
         .await

--- a/src/commands/pfp.rs
+++ b/src/commands/pfp.rs
@@ -1,3 +1,5 @@
+use serenity::builder::CreateEmbed;
+
 use super::*;
 
 /// Show the profile-picture of a user.
@@ -16,15 +18,20 @@ pub async fn pfp(ctx: &client::Context, msg: &Message, mut args: Args) -> Comman
     };
 
     let member = guild.member(&ctx, mentioned_user_id).await?;
-    let color = member.colour(&ctx);
 
-    msg.reply_embed(&ctx, |e| {
-        e.title(format!("{}'s profile picture", member.user.tag()));
-        e.color_opt(color);
-        e.image(member.face());
-    })
+    embeds::PaginatedEmbed::create(vec![
+        create_pfp_embed(&ctx, "Server's Profile Picture", member.face()).await,
+        create_pfp_embed(&ctx, "User's Profile Picture", member.user.face()).await,
+    ])
+    .await
+    .reply_to(&ctx, &msg)
     .await?;
-
     tracing::debug!("Replied with pfp");
     Ok(())
+}
+
+async fn create_pfp_embed(ctx: &client::Context, title: &str, image_url: String) -> CreateEmbed {
+    let mut e = embeds::basic_create_embed(&ctx).await;
+    e.title(title).image(image_url);
+    e
 }

--- a/src/commands/pfp.rs
+++ b/src/commands/pfp.rs
@@ -1,5 +1,7 @@
 use serenity::builder::CreateEmbed;
 
+use crate::embeds::basic_create_embed;
+
 use super::*;
 
 /// Show the profile-picture of a user.
@@ -19,10 +21,13 @@ pub async fn pfp(ctx: &client::Context, msg: &Message, mut args: Args) -> Comman
 
     let member = guild.member(&ctx, mentioned_user_id).await?;
 
-    embeds::PaginatedEmbed::create(vec![
-        create_pfp_embed(&ctx, "Server's Profile Picture", member.face()).await,
-        create_pfp_embed(&ctx, "User's Profile Picture", member.user.face()).await,
-    ])
+    embeds::PaginatedEmbed::create(
+        vec![
+            create_pfp_embed(&ctx, "Server's Profile Picture", member.face()).await,
+            create_pfp_embed(&ctx, "User's Profile Picture", member.user.face()).await,
+        ],
+        basic_create_embed(ctx).await,
+    )
     .await
     .reply_to(&ctx, &msg)
     .await?;

--- a/src/commands/pfp.rs
+++ b/src/commands/pfp.rs
@@ -1,6 +1,4 @@
-use serenity::builder::CreateEmbed;
-
-use crate::embeds::basic_create_embed;
+use crate::embeds::make_create_embed;
 
 use super::*;
 
@@ -23,20 +21,20 @@ pub async fn pfp(ctx: &client::Context, msg: &Message, mut args: Args) -> Comman
 
     embeds::PaginatedEmbed::create(
         vec![
-            create_pfp_embed(&ctx, "Server's Profile Picture", member.face()).await,
-            create_pfp_embed(&ctx, "User's Profile Picture", member.user.face()).await,
+            embeds::make_create_embed(&ctx, |e| {
+                e.title("Server's Profile Picture").image(member.face())
+            })
+            .await,
+            embeds::make_create_embed(&ctx, |e| {
+                e.title("User's Profile Picture").image(member.user.face())
+            })
+            .await,
         ],
-        basic_create_embed(ctx).await,
+        make_create_embed(ctx, |e| e).await,
     )
     .await
     .reply_to(&ctx, &msg)
     .await?;
     tracing::debug!("Replied with pfp");
     Ok(())
-}
-
-async fn create_pfp_embed(ctx: &client::Context, title: &str, image_url: String) -> CreateEmbed {
-    let mut e = embeds::basic_create_embed(&ctx).await;
-    e.title(title).image(image_url);
-    e
 }

--- a/src/commands/pfp.rs
+++ b/src/commands/pfp.rs
@@ -21,7 +21,7 @@ pub async fn pfp(ctx: &client::Context, msg: &Message, mut args: Args) -> Comman
     msg.reply_embed(&ctx, |e| {
         e.title(format!("{}'s profile picture", member.user.tag()));
         e.color_opt(color);
-        e.image(member.user.face());
+        e.image(member.face());
     })
     .await?;
 

--- a/src/embeds.rs
+++ b/src/embeds.rs
@@ -144,3 +144,110 @@ pub async fn basic_create_embed(ctx: &client::Context) -> CreateEmbed {
     });
     e
 }
+
+#[derive(Debug)]
+pub struct PaginatedEmbed {
+    embeds: Vec<CreateEmbed>,
+}
+
+impl PaginatedEmbed {
+    // implement a create method
+    pub async fn create(embeds: impl IntoIterator<Item = CreateEmbed>) -> PaginatedEmbed {
+        PaginatedEmbed {
+            embeds: embeds.into_iter().collect(),
+        }
+    }
+
+    #[tracing::instrument(skip_all, fields(?self, %msg.id))]
+    pub async fn reply_to(&self, ctx: &client::Context, msg: &Message) -> Result<Message> {
+        let pages = self.embeds.iter();
+        let pages = pages
+            .map(|e| {
+                let mut m = CreateMessage::default();
+                m.set_embed(e.clone());
+                m
+            })
+            .collect_vec();
+
+        if pages.len() < 2 {
+            Ok(msg
+                .channel_id
+                .send_message(&ctx, |m: &mut CreateMessage| {
+                    if let Some(create_message) = pages.first() {
+                        m.clone_from(create_message);
+                    }
+                    m.reference_message(msg)
+                })
+                .await?)
+        } else {
+            let mut current_page_idx = 0;
+            let created_msg = msg
+                .channel_id
+                .send_message(&ctx, |m| {
+                    m.clone_from(pages.get(current_page_idx).unwrap());
+                    m.reference_message(msg)
+                })
+                .await?;
+
+            let ctx = ctx.clone();
+            let user_id = msg.author.id;
+
+            tokio::spawn({
+                let mut created_msg = created_msg.clone();
+                let created_msg_id = created_msg.id;
+                async move {
+                    let res: Result<()> = async move {
+                        let emoji_left = ReactionType::from('◀');
+                        let emoji_right = ReactionType::from('▶');
+
+                        let reaction_left = created_msg.react(&ctx, emoji_left.clone()).await?;
+                        let reaction_right = created_msg.react(&ctx, emoji_right.clone()).await?;
+
+                        let mut collector = created_msg
+                            .await_reactions(&ctx)
+                            .timeout(std::time::Duration::from_secs(30))
+                            .collect_limit(10)
+                            .author_id(user_id)
+                            .filter(move |r| {
+                                r.emoji == reaction_left.emoji || r.emoji == reaction_right.emoji
+                            })
+                            .await;
+
+                        while let Some(reaction) = collector.next().await {
+                            let reaction = &reaction.as_ref().as_inner_ref();
+                            let emoji = &reaction.emoji;
+
+                            if emoji == &emoji_left && current_page_idx > 0 {
+                                current_page_idx -= 1;
+                            } else if emoji == &emoji_right && current_page_idx < pages.len() - 1 {
+                                current_page_idx += 1;
+                            }
+                            created_msg
+                                .edit(&ctx, |e| {
+                                    e.0.clone_from(&pages.get(current_page_idx).unwrap().0);
+                                    e
+                                })
+                                .await?;
+                            reaction.delete(&ctx).await?;
+                        }
+
+                        created_msg.delete_reactions(&ctx).await?;
+                        Ok(())
+                    }
+                    .instrument(
+                        tracing::info_span!("paginate-embed", embed_msg.id = %created_msg_id),
+                    )
+                    .await;
+                    if let Err(err) = res {
+                        log::error!("{}", err);
+                    }
+                }
+                .instrument(
+                    tracing::info_span!("paginate-embed-outer", embed_msg.id = %created_msg_id),
+                )
+            });
+
+            Ok(created_msg)
+        }
+    }
+}

--- a/src/embeds.rs
+++ b/src/embeds.rs
@@ -11,125 +11,6 @@ use serenity::{
 };
 use tracing_futures::Instrument;
 
-#[derive(Debug)]
-pub struct PaginatedFieldsEmbed {
-    create_embed: CreateEmbed,
-    fields: Vec<(String, String)>,
-}
-
-impl PaginatedFieldsEmbed {
-    pub async fn create(
-        ctx: &client::Context,
-        fields: impl IntoIterator<Item = (String, String)>,
-        build: impl FnOnce(&mut CreateEmbed),
-    ) -> PaginatedFieldsEmbed {
-        let mut embed = basic_create_embed(&ctx).await;
-        build(&mut embed);
-        PaginatedFieldsEmbed {
-            create_embed: embed,
-            fields: fields.into_iter().collect(),
-        }
-    }
-
-    #[tracing::instrument(skip_all, fields(?self, %msg.id))]
-    pub async fn reply_to(&self, ctx: &client::Context, msg: &Message) -> Result<Message> {
-        let pages = self.fields.iter().chunks(25);
-        let pages = pages
-            .into_iter()
-            .map(|fields| {
-                let mut m = CreateMessage::default();
-                let mut e = self.create_embed.clone();
-                e.fields(fields.map(|(k, v)| (k, v, false)).collect_vec());
-                m.set_embed(e);
-                m
-            })
-            .collect_vec();
-
-        if pages.len() < 2 {
-            Ok(msg
-                .channel_id
-                .send_message(&ctx, |m: &mut CreateMessage| {
-                    if let Some(create_message) = pages.first() {
-                        m.clone_from(create_message);
-                    } else {
-                        m.set_embed(self.create_embed.clone());
-                    }
-                    m.reference_message(msg)
-                })
-                .await?)
-        } else {
-            let mut current_page_idx = 0;
-            let created_msg = msg
-                .channel_id
-                .send_message(&ctx, |m| {
-                    m.clone_from(pages.get(current_page_idx).unwrap());
-                    m.reference_message(msg)
-                })
-                .await?;
-
-            let ctx = ctx.clone();
-            let user_id = msg.author.id;
-
-            tokio::spawn({
-                let mut created_msg = created_msg.clone();
-                let created_msg_id = created_msg.id;
-                async move {
-                    let res: Result<()> = async move {
-                        let emoji_left = ReactionType::from('◀');
-                        let emoji_right = ReactionType::from('▶');
-
-                        let reaction_left = created_msg.react(&ctx, emoji_left.clone()).await?;
-                        let reaction_right = created_msg.react(&ctx, emoji_right.clone()).await?;
-
-                        let mut collector = created_msg
-                            .await_reactions(&ctx)
-                            .timeout(std::time::Duration::from_secs(30))
-                            .collect_limit(10)
-                            .author_id(user_id)
-                            .filter(move |r| {
-                                r.emoji == reaction_left.emoji || r.emoji == reaction_right.emoji
-                            })
-                            .await;
-
-                        while let Some(reaction) = collector.next().await {
-                            let reaction = &reaction.as_ref().as_inner_ref();
-                            let emoji = &reaction.emoji;
-
-                            if emoji == &emoji_left && current_page_idx > 0 {
-                                current_page_idx -= 1;
-                            } else if emoji == &emoji_right && current_page_idx < pages.len() - 1 {
-                                current_page_idx += 1;
-                            }
-                            created_msg
-                                .edit(&ctx, |e| {
-                                    e.0.clone_from(&pages.get(current_page_idx).unwrap().0);
-                                    e
-                                })
-                                .await?;
-                            reaction.delete(&ctx).await?;
-                        }
-
-                        created_msg.delete_reactions(&ctx).await?;
-                        Ok(())
-                    }
-                    .instrument(
-                        tracing::info_span!("paginate-embed", embed_msg.id = %created_msg_id),
-                    )
-                    .await;
-                    if let Err(err) = res {
-                        log::error!("{}", err);
-                    }
-                }
-                .instrument(
-                    tracing::info_span!("paginate-embed-outer", embed_msg.id = %created_msg_id),
-                )
-            });
-
-            Ok(created_msg)
-        }
-    }
-}
-
 pub async fn basic_create_embed(ctx: &client::Context) -> CreateEmbed {
     let stare = ctx.get_random_stare().await;
 
@@ -148,13 +29,38 @@ pub async fn basic_create_embed(ctx: &client::Context) -> CreateEmbed {
 #[derive(Debug)]
 pub struct PaginatedEmbed {
     embeds: Vec<CreateEmbed>,
+    base_embed: CreateEmbed,
 }
 
 impl PaginatedEmbed {
     // implement a create method
-    pub async fn create(embeds: impl IntoIterator<Item = CreateEmbed>) -> PaginatedEmbed {
+    pub async fn create(
+        embeds: impl IntoIterator<Item = CreateEmbed>,
+        base_embed: CreateEmbed,
+    ) -> PaginatedEmbed {
         PaginatedEmbed {
             embeds: embeds.into_iter().collect(),
+            base_embed,
+        }
+    }
+
+    pub async fn create_from_fields(
+        fields: impl IntoIterator<Item = (String, String)>,
+        base_embed: CreateEmbed,
+    ) -> PaginatedEmbed {
+        let pages = fields.into_iter().chunks(25);
+        let pages = pages
+            .into_iter()
+            .map(|fields| {
+                let mut e = base_embed.clone();
+                e.fields(fields.map(|(k, v)| (k, v, false)).collect_vec());
+                e
+            })
+            .collect_vec();
+
+        PaginatedEmbed {
+            embeds: pages.into_iter().map(|f| f).collect(),
+            base_embed,
         }
     }
 
@@ -175,6 +81,8 @@ impl PaginatedEmbed {
                 .send_message(&ctx, |m: &mut CreateMessage| {
                     if let Some(create_message) = pages.first() {
                         m.clone_from(create_message);
+                    } else {
+                        m.set_embed(self.base_embed.clone());
                     }
                     m.reference_message(msg)
                 })

--- a/src/embeds.rs
+++ b/src/embeds.rs
@@ -145,7 +145,10 @@ impl PaginatedEmbed {
     }
 }
 
-pub async fn basic_create_embed(ctx: &client::Context) -> CreateEmbed {
+pub async fn make_create_embed(
+    ctx: &client::Context,
+    build: impl FnOnce(&mut CreateEmbed) -> &mut CreateEmbed,
+) -> CreateEmbed {
     let stare = ctx.get_random_stare().await;
 
     let mut e = CreateEmbed::default();
@@ -157,5 +160,7 @@ pub async fn basic_create_embed(ctx: &client::Context) -> CreateEmbed {
         }
         f.text("\u{200b}")
     });
+
+    build(&mut e);
     e
 }

--- a/src/embeds.rs
+++ b/src/embeds.rs
@@ -18,7 +18,6 @@ pub struct PaginatedEmbed {
 }
 
 impl PaginatedEmbed {
-    // implement a create method
     pub async fn create(
         embeds: impl IntoIterator<Item = CreateEmbed>,
         base_embed: CreateEmbed,
@@ -44,7 +43,7 @@ impl PaginatedEmbed {
             .collect_vec();
 
         PaginatedEmbed {
-            embeds: pages.into_iter().map(|f| f).collect(),
+            embeds: pages,
             base_embed,
         }
     }

--- a/src/embeds.rs
+++ b/src/embeds.rs
@@ -11,21 +11,6 @@ use serenity::{
 };
 use tracing_futures::Instrument;
 
-pub async fn basic_create_embed(ctx: &client::Context) -> CreateEmbed {
-    let stare = ctx.get_random_stare().await;
-
-    let mut e = CreateEmbed::default();
-
-    e.timestamp(&Utc::now());
-    e.footer(|f| {
-        if let Some(emoji) = stare {
-            f.icon_url(emoji.url());
-        }
-        f.text("\u{200b}")
-    });
-    e
-}
-
 #[derive(Debug)]
 pub struct PaginatedEmbed {
     embeds: Vec<CreateEmbed>,
@@ -158,4 +143,19 @@ impl PaginatedEmbed {
             Ok(created_msg)
         }
     }
+}
+
+pub async fn basic_create_embed(ctx: &client::Context) -> CreateEmbed {
+    let stare = ctx.get_random_stare().await;
+
+    let mut e = CreateEmbed::default();
+
+    e.timestamp(&Utc::now());
+    e.footer(|f| {
+        if let Some(emoji) = stare {
+            f.icon_url(emoji.url());
+        }
+        f.text("\u{200b}")
+    });
+    e
 }

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,4 +1,4 @@
-use crate::{db::Db, embeds::basic_create_embed, Config, UpEmotes};
+use crate::{db::Db, embeds::make_create_embed, Config, UpEmotes};
 use anyhow::{Context, Result};
 use itertools::Itertools;
 use serenity::{
@@ -93,8 +93,11 @@ impl GuildIdExt for GuildId {
     where
         F: FnOnce(&mut CreateEmbed) + Send + Sync,
     {
-        let mut create_embed = basic_create_embed(&ctx).await;
-        build(&mut create_embed);
+        let create_embed = make_create_embed(&ctx, |e| {
+            build(e);
+            e
+        })
+        .await;
         Ok(channel_id
             .send_message(&ctx, |m| m.set_embed(create_embed))
             .await
@@ -157,8 +160,11 @@ impl MessageExt for Message {
     where
         F: FnOnce(&mut CreateEmbed) + Send + Sync,
     {
-        let mut create_embed = basic_create_embed(&ctx).await;
-        build(&mut create_embed);
+        let create_embed = make_create_embed(&ctx, |e| {
+            build(e);
+            e
+        })
+        .await;
 
         self.channel_id
             .send_message(&ctx, move |m| {
@@ -268,8 +274,11 @@ impl ChannelIdExt for ChannelId {
     where
         F: FnOnce(&mut CreateEmbed) + Send + Sync,
     {
-        let mut create_embed = basic_create_embed(&ctx).await;
-        build(&mut create_embed);
+        let create_embed = make_create_embed(&ctx, |e| {
+            build(e);
+            e
+        })
+        .await;
         Ok(self
             .send_message(&ctx, |m| m.set_embed(create_embed))
             .await


### PR DESCRIPTION
This PR adds support for viewing both server and user specific profile pictures with the `!pfp` command. It also changes PaginatedFieldsEmbed to be more generic (PaginatedEmbed) so that it can be used for non-textual embeds.
