### PR TITLE
Implement mass banning users (implements #289 and implements #305)

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -64,7 +64,7 @@ async fn check_role(ctx: &client::Context, msg: &Message, role: RoleId) -> Resul
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum PermissionLevel {
     Mod,
     Helper,

--- a/src/db/highlights.rs
+++ b/src/db/highlights.rs
@@ -5,10 +5,7 @@ use std::collections::HashSet;
 fn combine_multitrigger_regex<'a, I: IntoIterator<Item = &'a str>>(
     words: I,
 ) -> Result<regex::Regex> {
-    let joined_words = words
-        .into_iter()
-        .map(|element| regex::escape(element))
-        .join("|");
+    let joined_words = words.into_iter().map(regex::escape).join("|");
     let mut regex_builder = regex::RegexBuilder::new(&format!(r"\b(?:{})\b", joined_words));
     regex_builder
         .case_insensitive(true)


### PR DESCRIPTION
This PR adds the option to ban multiple users via `!ban id,id2,id3,id4,... reason`.
It also changes the ban restrictions for helpers to be based on the join date
