### PR TITLE
Add the root cause to any anyhow error logs

### DIFF
--- a/crates/robbb_util/src/util.rs
+++ b/crates/robbb_util/src/util.rs
@@ -22,13 +22,24 @@ macro_rules! abort_with {
 macro_rules! log_error {
     ($e:expr) => {
         if let Err(e) = $e {
-            tracing::error!(error.message = %format!("{}", &e), "{:?}", e);
+            let e = anyhow::anyhow!(e);
+            tracing::error!(
+                error.message = %&e,
+                error.root_cause = %e.root_cause(),
+                "{:?}",
+                e
+            );
         }
     };
     ($context:expr, $e:expr $(,)?) => {
         if let Err(e) = $e {
-            let e = format!("{:?}", ::anyhow::anyhow!(e).context($context));
-            tracing::error!(error.message = %format!("{}", &e), "{:?}", e);
+            let e = ::anyhow::anyhow!(e).context($context);
+            tracing::error!(
+                error.message = %&e,
+                error.root_cause = %e.root_cause(),
+                "{:?}",
+                e
+            );
         }
     };
 }


### PR DESCRIPTION
This PR adds the root cause to the logs of any errors.
This is mostly useful so we can more easily track errors in honeycomb, 
checking for commonly occuring root causes and finding out what consequences those have.
