### PR TITLE
Update poise and serenity, fix broken ask command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,8 +1192,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "poise"
-version = "0.2.1"
-source = "git+https://github.com/kangalioo/poise?rev=0f2eb876397d1712d38432adc759ca3b9186d7ff#0f2eb876397d1712d38432adc759ca3b9186d7ff"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ca787e4e516076de1995a83ee05fbdfed71d072ea0da3df018318db42a87803"
 dependencies = [
  "async-trait",
  "derivative",
@@ -1201,6 +1202,7 @@ dependencies = [
  "futures-util",
  "log",
  "once_cell",
+ "parking_lot 0.12.1",
  "poise_macros",
  "regex",
  "serenity",
@@ -1209,8 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "poise_macros"
-version = "0.2.1"
-source = "git+https://github.com/kangalioo/poise?rev=0f2eb876397d1712d38432adc759ca3b9186d7ff#0f2eb876397d1712d38432adc759ca3b9186d7ff"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b80c1f4e04114527f9d41ed6bb31707a095276f51bb0aef3ca11f062b25a67c4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1663,8 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "serenity"
-version = "0.11.4"
-source = "git+https://github.com/bumblepie/serenity?rev=1fba7ba6bcf0a9fd4f645c265b42fe9bf8c45bc4#1fba7ba6bcf0a9fd4f645c265b42fe9bf8c45bc4"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fd5e7b5858ad96e99d440138f34f5b98e1b959ebcd3a1036203b30e78eb788"
 dependencies = [
  "async-trait",
  "async-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ split-debuginfo = "unpacked"
 
 
 [patch.crates-io]
-poise = { git = "https://github.com/kangalioo/poise", rev = "0f2eb876397d1712d38432adc759ca3b9186d7ff" }
-serenity = { git = "https://github.com/bumblepie/serenity", rev = "1fba7ba6bcf0a9fd4f645c265b42fe9bf8c45bc4" }
+#poise = { git = "https://github.com/kangalioo/poise", rev = "0f2eb876397d1712d38432adc759ca3b9186d7ff" }
+#serenity = { git = "https://github.com/bumblepie/serenity", rev = "1fba7ba6bcf0a9fd4f645c265b42fe9bf8c45bc4" }
 #serenity = { git = "https://github.com/serenity-rs/serenity", rev = "5363f2a8a362dc9bc210c9a87da985d43ab7faca" }

--- a/crates/robbb/Cargo.toml
+++ b/crates/robbb/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 #serenity = { git = "https://github.com/serenity-rs/serenity/", branch = "next", features = ["collector"]}
-serenity = { version = "0.11.2", default-features = false, features = ["collector", "builder", "cache", "chrono", "client", "gateway", "model", "http", "utils"]}
+serenity = { version = "0.11.5", default-features = false, features = ["collector", "builder", "cache", "chrono", "client", "gateway", "model", "http", "utils"]}
 anyhow = "1.0"
 chrono = "0.4"
 chrono-humanize = "0.2"
@@ -31,7 +31,7 @@ futures = "0.3"
 unicase = "2.6.0"
 
 cpu-monitor = "0.1.1"
-poise = "0.2"
+poise = "0.5.2"
 parking_lot = "0.12"
 
 tracing = "0.1.37"

--- a/crates/robbb/src/error_handling.rs
+++ b/crates/robbb/src/error_handling.rs
@@ -18,10 +18,10 @@ pub async fn on_error(error: poise::FrameworkError<'_, UserData, prelude::Error>
         Command { error, ctx } => {
             handle_command_error(ctx, error).await;
         }
-        Setup { error } => {
+        Setup { error, .. } => {
             tracing::error!(error = %error, "Error during setup: {}", error)
         }
-        Listener { error, event, ctx: _, framework: _ } => {
+        EventHandler { error, event, ctx: _, framework: _ } => {
             tracing::error!(event = ?event, error = %error, "Error in event listener: {}", error);
         }
         ArgumentParse { input, ctx, error } => {
@@ -89,7 +89,7 @@ pub async fn on_error(error: poise::FrameworkError<'_, UserData, prelude::Error>
                 );
             }
         }
-        DynamicPrefix { error } => {
+        DynamicPrefix { error, .. } => {
             tracing::error!(error = %error, "Error in dynamic prefix");
         }
         other => {

--- a/crates/robbb/src/events/handle_blocklist.rs
+++ b/crates/robbb/src/events/handle_blocklist.rs
@@ -229,9 +229,7 @@ fn collect_interaction_values(interaction: &Interaction) -> Option<InteractionVa
 /// Recursively traverse an `ApplicationCommandInteractionDataOption`
 /// to get all the `ApplicationCommandInteractionDataOptionValue`s of it and it's subcommands / groups
 #[allow(deprecated)]
-fn get_options_from_option(
-    option: &poise::serenity_prelude::ApplicationCommandInteractionDataOption,
-) -> Vec<&str> {
+fn get_options_from_option(option: &poise::serenity_prelude::CommandDataOption) -> Vec<&str> {
     let mut values = Vec::new();
     if let Some(value) = option.value.as_ref().and_then(|x| x.as_str()) {
         values.push(value);

--- a/crates/robbb/src/main.rs
+++ b/crates/robbb/src/main.rs
@@ -105,8 +105,11 @@ async fn pre_command(ctx: Ctx<'_>) -> bool {
         poise::Context::Application(_) => "<slash command>".to_string(),
         poise::Context::Prefix(prefix) => prefix.msg.content.to_string(),
     };
-    let channel_name =
-        ctx.channel_id().to_channel_cached(&ctx.discord()).and_then(|x| x.guild()).map(|x| x.name);
+    let channel_name = ctx
+        .channel_id()
+        .to_channel_cached(&ctx.serenity_context())
+        .and_then(|x| x.guild())
+        .map(|x| x.name);
 
     let span = tracing::Span::current();
     span.record("command_name", &ctx.command().qualified_name.as_str());

--- a/crates/robbb_commands/Cargo.toml
+++ b/crates/robbb_commands/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serenity = { version = "0.11.2", default-features = false, features = ["collector", "builder", "cache", "chrono", "client", "gateway", "model", "http", "utils"]}
+serenity = { version = "0.11.5", default-features = false, features = ["collector", "builder", "cache", "chrono", "client", "gateway", "model", "http", "utils"]}
 anyhow = "1.0"
 chrono = "0.4"
 chrono-humanize = "0.2"
@@ -28,7 +28,7 @@ unicase = "2.6.0"
 
 tracing = "0.1.37"
 tracing-futures = "0.2.5"
-poise = "0.2"
+poise = "0.5.2"
 parking_lot = "0.12.1"
 
 robbb_db = { path = "../robbb_db" }

--- a/crates/robbb_commands/src/checks.rs
+++ b/crates/robbb_commands/src/checks.rs
@@ -23,18 +23,18 @@ pub async fn check_channel_allows_commands(ctx: Ctx<'_>) -> Res<bool> {
 #[tracing::instrument(skip_all)]
 pub async fn check_is_moderator(ctx: Ctx<'_>) -> Res<bool> {
     let config = ctx.get_config();
-    check_role(ctx.discord(), ctx.author(), config.role_mod).await
+    check_role(ctx.serenity_context(), ctx.author(), config.role_mod).await
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn check_is_helper(ctx: Ctx<'_>) -> Res<bool> {
     let config = ctx.get_config();
-    check_role(ctx.discord(), ctx.author(), config.role_helper).await
+    check_role(ctx.serenity_context(), ctx.author(), config.role_helper).await
 }
 
 #[tracing::instrument(skip_all)]
 pub async fn check_is_helper_or_mod(ctx: Ctx<'_>) -> Res<bool> {
-    let permission_level = get_permission_level(ctx.discord(), ctx.author()).await?;
+    let permission_level = get_permission_level(ctx.serenity_context(), ctx.author()).await?;
     match permission_level {
         PermissionLevel::User => Ok(false),
         PermissionLevel::Helper | PermissionLevel::Mod => Ok(true),
@@ -45,7 +45,7 @@ pub async fn check_is_helper_or_mod(ctx: Ctx<'_>) -> Res<bool> {
 pub async fn check_is_not_muted(ctx: Ctx<'_>) -> Res<bool> {
     let config = ctx.get_config();
 
-    check_role(ctx.discord(), ctx.author(), config.role_mute).await.map(|x| !x)
+    check_role(ctx.serenity_context(), ctx.author(), config.role_mute).await.map(|x| !x)
 }
 
 #[tracing::instrument(skip_all, fields(user_id = %user.id.0, role_id = %role.0))]

--- a/crates/robbb_commands/src/commands/ask.rs
+++ b/crates/robbb_commands/src/commands/ask.rs
@@ -45,7 +45,10 @@ pub async fn ask(
 
     let AskModal { title, details } = AskModal::execute_with_defaults(
         app_ctx,
-        AskModal { title: String::new(), details: question.unwrap_or_default() },
+        AskModal {
+            title: "<Summarize your question>".to_string(),
+            details: question.unwrap_or_else(|| "Provide some details...".to_string()),
+        },
     )
     .instrument(tracing::info_span!("wait for modal response"))
     .await?

--- a/crates/robbb_commands/src/commands/blocklist.rs
+++ b/crates/robbb_commands/src/commands/blocklist.rs
@@ -92,7 +92,7 @@ pub async fn blocklist_list(ctx: Ctx<'_>) -> Res<()> {
 async fn autocomplete_blocklist_entry(ctx: Ctx<'_>, partial: &str) -> Vec<String> {
     let db = ctx.get_db();
     if let Ok(blocklist) = db.get_blocklist().await {
-        blocklist.iter().filter(|x| x.contains(&partial)).map(|x| x.to_string()).collect_vec()
+        blocklist.iter().filter(|x| x.contains(partial)).map(|x| x.to_string()).collect_vec()
     } else {
         Vec::new()
     }

--- a/crates/robbb_commands/src/commands/fetch/fetch.rs
+++ b/crates/robbb_commands/src/commands/fetch/fetch.rs
@@ -24,7 +24,7 @@ pub async fn fetch(
 
     let create_date = fetch_info.create_date;
     let fetch_data: Vec<(FetchField, String)> = fetch_info.get_values_ordered();
-    let color = user.colour(&ctx.discord());
+    let color = user.colour(&ctx.serenity_context());
 
     match field {
         // Handle fetching a single field

--- a/crates/robbb_commands/src/commands/fetch/fetch.rs
+++ b/crates/robbb_commands/src/commands/fetch/fetch.rs
@@ -24,7 +24,7 @@ pub async fn fetch(
 
     let create_date = fetch_info.create_date;
     let fetch_data: Vec<(FetchField, String)> = fetch_info.get_values_ordered();
-    let color = user.colour(&ctx.serenity_context());
+    let color = user.colour(ctx.serenity_context());
 
     match field {
         // Handle fetching a single field

--- a/crates/robbb_commands/src/commands/fetch/setfetch.rs
+++ b/crates/robbb_commands/src/commands/fetch/setfetch.rs
@@ -75,7 +75,7 @@ pub async fn set_fetch_update(
 
     let memory = if let Some(memory) = memory {
         Some(
-            byte_unit::Byte::from_str(&memory)
+            byte_unit::Byte::from_str(memory)
                 .user_error("Malformed value provided for Memory")?
                 .get_bytes()
                 .to_string(),

--- a/crates/robbb_commands/src/commands/fetch/setfetch.rs
+++ b/crates/robbb_commands/src/commands/fetch/setfetch.rs
@@ -64,7 +64,7 @@ pub async fn set_fetch_update(
     let image = match (image, config.channel_attachment_dump) {
         (Some(image), Some(dump_channel)) => {
             ctx.defer().await?;
-            Some(dump_attachment(&ctx.discord(), dump_channel, image).await?)
+            Some(dump_attachment(&ctx.serenity_context(), dump_channel, image).await?)
         }
         (None, _) => None,
         (Some(image), None) => {

--- a/crates/robbb_commands/src/commands/help.rs
+++ b/crates/robbb_commands/src/commands/help.rs
@@ -86,12 +86,7 @@ async fn reply_help_full(ctx: Ctx<'_>, commands: &[&Command<UserData, Error>]) -
         } else {
             format!("**!{}**", command.name)
         };
-        let description = command
-            .description
-            .as_ref()
-            .map(|x| x.as_str())
-            .unwrap_or("No description")
-            .to_string();
+        let description = command.description.as_deref().unwrap_or("No description").to_string();
         (name, description)
     });
 

--- a/crates/robbb_commands/src/commands/highlights.rs
+++ b/crates/robbb_commands/src/commands/highlights.rs
@@ -151,7 +151,7 @@ async fn autocomplete_highlights(ctx: Ctx<'_>, partial: &str) -> Vec<String> {
     if let Ok(highlights) = db.get_highlights().await {
         highlights
             .triggers_for_user(ctx.author().id)
-            .filter(|x| x.contains(&partial))
+            .filter(|x| x.contains(partial))
             .map(|x| x.to_string())
             .collect_vec()
     } else {

--- a/crates/robbb_commands/src/commands/highlights.rs
+++ b/crates/robbb_commands/src/commands/highlights.rs
@@ -25,10 +25,11 @@ pub async fn highlights_add(
     }
 
     let db = ctx.get_db();
-    let max_highlight_cnt = match checks::get_permission_level(ctx.discord(), ctx.author()).await? {
-        PermissionLevel::Mod => 20,
-        _ => 4,
-    };
+    let max_highlight_cnt =
+        match checks::get_permission_level(ctx.serenity_context(), ctx.author()).await? {
+            PermissionLevel::Mod => 20,
+            _ => 4,
+        };
 
     let highlights = db.get_highlights().await?;
     let highlights_by_user_cnt = highlights.triggers_for_user(ctx.author().id).count();
@@ -42,10 +43,10 @@ pub async fn highlights_add(
 
     ctx.author()
         .id
-        .create_dm_channel(&ctx.discord())
+        .create_dm_channel(&ctx.serenity_context())
         .await
         .user_error("Couldn't open a DM to you - do you have me blocked?")?
-        .send_message(&ctx.discord(), |m| {
+        .send_message(&ctx.serenity_context(), |m| {
             m.embed(|e| {
                 e.title("Test to see if you can receive DMs");
                 e.description(format!(
@@ -129,10 +130,10 @@ async fn try_dm_or_ephemeral_response(
         poise::Context::Prefix(_) => {
             ctx.author()
                 .id
-                .create_dm_channel(&ctx.discord())
+                .create_dm_channel(&ctx.serenity_context())
                 .await
                 .user_error("Couldn't open a DM to you - do you have me blocked?")?
-                .send_message(&ctx.discord(), |m| {
+                .send_message(&ctx.serenity_context(), |m| {
                     m.embed(|e| {
                         build(e);
                         e

--- a/crates/robbb_commands/src/commands/info.rs
+++ b/crates/robbb_commands/src/commands/info.rs
@@ -13,7 +13,7 @@ use super::*;
     custom_data = "CmdMeta { perms: PermissionLevel::User }"
 )]
 pub async fn menu_info(ctx: Ctx<'_>, user: User) -> Res<()> {
-    let member = ctx.guild().unwrap().member(ctx.discord(), &user).await?;
+    let member = ctx.guild().unwrap().member(ctx.serenity_context(), &user).await?;
     let embed = if check_is_moderator(ctx).await? {
         make_mod_info_embed(ctx, member).await?
     } else {
@@ -62,8 +62,8 @@ pub async fn modinfo(ctx: Ctx<'_>, #[description = "User"] user: Member) -> Res<
 
 async fn make_info_embed(ctx: Ctx<'_>, member: Member) -> CreateEmbed {
     let created_at = member.user.created_at();
-    let color = member.colour(ctx.discord());
-    embeds::make_create_embed(ctx.discord(), |e| {
+    let color = member.colour(ctx.serenity_context());
+    embeds::make_create_embed(ctx.serenity_context(), |e| {
         e.title(member.user.tag());
         e.thumbnail(member.user.face());
         e.color_opt(color);

--- a/crates/robbb_commands/src/commands/kick.rs
+++ b/crates/robbb_commands/src/commands/kick.rs
@@ -25,7 +25,7 @@ pub async fn kick(
 ) -> Res<()> {
     let db = ctx.get_db();
     let guild = ctx.guild().context("Failed to fetch guild")?;
-    do_kick(ctx.discord(), guild, &user, &reason).await?;
+    do_kick(ctx.serenity_context(), guild, &user, &reason).await?;
 
     let success_msg = ctx
         .say_success_mod_action(format!("{} has been kicked from the server", user.id.mention()))

--- a/crates/robbb_commands/src/commands/move_users.rs
+++ b/crates/robbb_commands/src/commands/move_users.rs
@@ -71,7 +71,7 @@ async fn send_move(ctx: Ctx<'_>, target_channel: ChannelId, mentions: String) ->
         ctx: Ctx<'_>,
         continuation_msg: Option<Cow<'a, Message>>,
     ) -> CreateEmbed {
-        make_create_embed(ctx.discord(), |e| {
+        make_create_embed(ctx.serenity_context(), |e| {
             e.author_user(ctx.author());
             e.description(indoc::formatdoc!(
                 "Continuation from {}
@@ -86,7 +86,9 @@ async fn send_move(ctx: Ctx<'_>, target_channel: ChannelId, mentions: String) ->
     let mut continuation_msg = {
         let continuation_embed = make_continuation_embed(ctx, None).await;
         target_channel
-            .send_message(&ctx.discord(), |m| m.content(mentions).set_embed(continuation_embed))
+            .send_message(&ctx.serenity_context(), |m| {
+                m.content(mentions).set_embed(continuation_embed)
+            })
             .await?
     };
 
@@ -115,10 +117,10 @@ async fn send_move(ctx: Ctx<'_>, target_channel: ChannelId, mentions: String) ->
     let move_message = move_message.message().await?;
 
     let new_continuation_embed = make_continuation_embed(ctx, Some(move_message)).await;
-    continuation_msg.edit(&ctx.discord(), |m| m.set_embed(new_continuation_embed)).await?;
+    continuation_msg.edit(&ctx.serenity_context(), |m| m.set_embed(new_continuation_embed)).await?;
 
     if let poise::Context::Prefix(ctx) = ctx {
-        ctx.msg.delete(&ctx.discord).await?;
+        ctx.msg.delete(&ctx.serenity_context()).await?;
     }
     Ok(())
 }

--- a/crates/robbb_commands/src/commands/mute.rs
+++ b/crates/robbb_commands/src/commands/mute.rs
@@ -26,7 +26,7 @@ struct MuteModal {
 )]
 pub async fn menu_mute(app_ctx: AppCtx<'_>, user: User) -> Res<()> {
     let ctx = Ctx::Application(app_ctx);
-    let member = ctx.guild().unwrap().member(&ctx.discord(), user.id).await?;
+    let member = ctx.guild().unwrap().member(&ctx.serenity_context(), user.id).await?;
     let ctx = Ctx::Application(app_ctx);
     let interaction = match app_ctx.interaction {
         poise::ApplicationCommandOrAutocompleteInteraction::ApplicationCommand(x) => x,
@@ -77,7 +77,7 @@ async fn do_mute(
     let success_msg = success_msg.message().await?;
 
     apply_mute(
-        ctx.discord(),
+        ctx.serenity_context(),
         ctx.author().id,
         member.clone(),
         *duration,

--- a/crates/robbb_commands/src/commands/note.rs
+++ b/crates/robbb_commands/src/commands/note.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use chrono::Utc;
 use poise::{
     serenity_prelude::{Mentionable, User},
@@ -101,7 +102,8 @@ pub async fn note_edit(
 
     let NoteEditModal { reason } =
         NoteEditModal::execute_with_defaults(app_ctx, NoteEditModal { reason: action.reason })
-            .await?;
+            .await?
+            .context("Modal timed out")?;
     let reason = reason.trim().trim_matches('\n');
 
     db.edit_mod_action_reason(action.id, ctx.author().id, reason.to_string()).await?;
@@ -149,7 +151,7 @@ pub async fn note_list(
         )
     });
 
-    let base_embed = embeds::make_create_embed(ctx.discord(), |e| {
+    let base_embed = embeds::make_create_embed(ctx.serenity_context(), |e| {
         e.description(format!("{} notes about {}", notes.len(), user.mention()));
         e.author_user(&user)
     })

--- a/crates/robbb_commands/src/commands/pfp.rs
+++ b/crates/robbb_commands/src/commands/pfp.rs
@@ -17,7 +17,7 @@ pub async fn pfp(ctx: Ctx<'_>, #[description = "User"] user: Option<Member>) -> 
 
     if user_pfp != server_pfp {
         embeds.push(
-            embeds::make_create_embed(ctx.discord(), |e| {
+            embeds::make_create_embed(ctx.serenity_context(), |e| {
                 e.title(format!("{}'s Server Profile Picture", member.user.tag()))
                     .image(member.face())
             })
@@ -26,16 +26,19 @@ pub async fn pfp(ctx: Ctx<'_>, #[description = "User"] user: Option<Member>) -> 
     }
 
     embeds.push(
-        embeds::make_create_embed(ctx.discord(), |e| {
+        embeds::make_create_embed(ctx.serenity_context(), |e| {
             e.title(format!("{}'s User Profile Picture", member.user.tag()))
                 .image(member.user.face())
         })
         .await,
     );
 
-    embeds::PaginatedEmbed::create(embeds, embeds::make_create_embed(ctx.discord(), |e| e).await)
-        .await
-        .reply_to(ctx, false)
-        .await?;
+    embeds::PaginatedEmbed::create(
+        embeds,
+        embeds::make_create_embed(ctx.serenity_context(), |e| e).await,
+    )
+    .await
+    .reply_to(ctx, false)
+    .await?;
     Ok(())
 }

--- a/crates/robbb_commands/src/commands/poise_commands.rs
+++ b/crates/robbb_commands/src/commands/poise_commands.rs
@@ -22,10 +22,11 @@ pub async fn delete(
 ) -> Res<()> {
     if global {
         #[allow(deprecated)]
-        let global_commands = Command::get_global_application_commands(ctx.discord()).await?;
+        let global_commands =
+            Command::get_global_application_commands(ctx.serenity_context()).await?;
         for command in &global_commands {
             tracing::debug!(deleted_command_name = %command.name, "Deleting global application command {}", command.name);
-            Command::delete_global_application_command(ctx.discord(), command.id).await?;
+            Command::delete_global_application_command(ctx.serenity_context(), command.id).await?;
         }
 
         ctx.say_success(format!(
@@ -34,10 +35,10 @@ pub async fn delete(
         ))
         .await?;
     } else if let Some(guild) = ctx.guild() {
-        let commands = guild.get_application_commands(ctx.discord()).await?;
+        let commands = guild.get_application_commands(ctx.serenity_context()).await?;
         for command in &commands {
             tracing::debug!(deleted_command_name = %command.name, "Deleting application command {}", command.name);
-            guild.delete_application_command(ctx.discord(), command.id).await?;
+            guild.delete_application_command(ctx.serenity_context(), command.id).await?;
         }
         ctx.say_success(format!(
             "Deleted application commands: {}",
@@ -67,14 +68,14 @@ pub async fn register(
     let commands_builder = poise::builtins::create_application_commands(new_commands);
     println!("{:?}", new_commands);
     if global {
-        Command::set_global_application_commands(ctx.discord(), |b| {
+        Command::set_global_application_commands(ctx.serenity_context(), |b| {
             *b = commands_builder;
             b
         })
         .await?;
     } else if let Some(guild) = ctx.guild() {
         guild
-            .set_application_commands(ctx.discord(), |b| {
+            .set_application_commands(ctx.serenity_context(), |b| {
                 *b = commands_builder;
                 b
             })
@@ -83,7 +84,7 @@ pub async fn register(
 
     ctx.say_success(format!(
         "Registered commands: {}",
-        new_commands.iter().map(|x| x.name).join(", ")
+        new_commands.iter().map(|x| x.name.as_str()).join(", ")
     ))
     .await?;
 

--- a/crates/robbb_commands/src/commands/poll.rs
+++ b/crates/robbb_commands/src/commands/poll.rs
@@ -1,4 +1,5 @@
 use super::*;
+use anyhow::Context;
 use poise::{serenity_prelude::ReactionType, Modal};
 use regex::Regex;
 
@@ -43,15 +44,15 @@ pub async fn poll_vote(
         .await?;
 
     let poll_msg = poll_msg.message().await?;
-    poll_msg.react(&ctx.discord(), ReactionType::Unicode("✅".to_string())).await?;
-    poll_msg.react(&ctx.discord(), ReactionType::Unicode("🤷".to_string())).await?;
-    poll_msg.react(&ctx.discord(), ReactionType::Unicode("❎".to_string())).await?;
+    poll_msg.react(&ctx.serenity_context(), ReactionType::Unicode("✅".to_string())).await?;
+    poll_msg.react(&ctx.serenity_context(), ReactionType::Unicode("🤷".to_string())).await?;
+    poll_msg.react(&ctx.serenity_context(), ReactionType::Unicode("❎".to_string())).await?;
 
     let config = ctx.get_config();
     if ctx.channel_id() == config.channel_mod_polls {
         poll_msg
             .create_thread(
-                ctx.discord(),
+                ctx.serenity_context(),
                 util::thread_title_from_text(&question).unwrap_or_else(|_| "Poll".to_string()),
             )
             .await?;
@@ -83,7 +84,7 @@ struct MultiPollModal {
 pub async fn poll_multi(app_ctx: AppCtx<'_>) -> Res<()> {
     let ctx = poise::Context::Application(app_ctx);
 
-    let modal_result = MultiPollModal::execute(app_ctx).await?;
+    let modal_result = MultiPollModal::execute(app_ctx).await?.context("Modal timed out")?;
 
     let options_lines = modal_result.options.lines().collect_vec();
 
@@ -115,15 +116,15 @@ pub async fn poll_multi(app_ctx: AppCtx<'_>) -> Res<()> {
     let poll_msg = poll_msg.message().await?;
 
     for (emoji, _) in options.into_iter() {
-        poll_msg.react(&ctx.discord(), ReactionType::Unicode(emoji.to_string())).await?;
+        poll_msg.react(&ctx.serenity_context(), ReactionType::Unicode(emoji.to_string())).await?;
     }
-    poll_msg.react(&ctx.discord(), ReactionType::Unicode("🤷".to_string())).await?;
+    poll_msg.react(&ctx.serenity_context(), ReactionType::Unicode("🤷".to_string())).await?;
 
     let config = ctx.get_config();
     if ctx.channel_id() == config.channel_mod_polls {
         poll_msg
             .create_thread(
-                ctx.discord(),
+                ctx.serenity_context(),
                 util::thread_title_from_text(&modal_result.title)
                     .unwrap_or_else(|_| "Poll".to_string()),
             )

--- a/crates/robbb_commands/src/commands/purge.rs
+++ b/crates/robbb_commands/src/commands/purge.rs
@@ -38,7 +38,7 @@ pub async fn purge(
     let _working = ctx.defer_or_broadcast().await?;
 
     let recent_messages = channel
-        .messages(&ctx.discord(), |m| m.limit(100).before(response_msg.id))
+        .messages(&ctx.serenity_context(), |m| m.limit(100).before(response_msg.id))
         .await?
         .into_iter()
         .filter(|msg| msg.author.id == user)
@@ -50,13 +50,13 @@ pub async fn purge(
         .take(count)
         .collect_vec();
 
-    channel.delete_messages(&ctx.discord(), &recent_messages).await?;
+    channel.delete_messages(&ctx.serenity_context(), &recent_messages).await?;
 
     let success_embed = embeds::make_success_mod_action_embed(
-        ctx.discord(),
+        ctx.serenity_context(),
         &format!("Successfully deleted {} messages", recent_messages.len()),
     )
     .await;
-    response_msg.to_mut().edit(&ctx.discord(), |e| e.set_embed(success_embed)).await?;
+    response_msg.to_mut().edit(&ctx.serenity_context(), |e| e.set_embed(success_embed)).await?;
     Ok(())
 }

--- a/crates/robbb_commands/src/commands/role.rs
+++ b/crates/robbb_commands/src/commands/role.rs
@@ -44,7 +44,7 @@ pub async fn role(ctx: Ctx<'_>) -> Res<()> {
 
     if let Some(interaction) = roles_msg
         .to_mut()
-        .await_component_interactions(&ctx.serenity_context())
+        .await_component_interactions(ctx.serenity_context())
         .author_id(ctx.author().id)
         .timeout(std::time::Duration::from_secs(10))
         .collect_limit(1)

--- a/crates/robbb_commands/src/commands/small.rs
+++ b/crates/robbb_commands/src/commands/small.rs
@@ -13,7 +13,7 @@ use super::*;
 )]
 pub async fn restart(ctx: Ctx<'_>) -> Res<()> {
     let _ = ctx.say_success("Shutting down").await;
-    ctx.discord().shard.shutdown_clean();
+    ctx.serenity_context().shard.shutdown_clean();
     std::process::exit(1);
 }
 
@@ -29,7 +29,7 @@ pub async fn say(
     #[description = "What you,.. ummmm. I mean _I_ should say"] message: String,
 ) -> Res<()> {
     ctx.send(|m| m.content("Sure thing!").ephemeral(true)).await?;
-    ctx.channel_id().say(&ctx.discord(), message).await?;
+    ctx.channel_id().say(&ctx.serenity_context(), message).await?;
     Ok(())
 }
 

--- a/crates/robbb_commands/src/commands/top.rs
+++ b/crates/robbb_commands/src/commands/top.rs
@@ -99,7 +99,7 @@ async fn top_for_field(ctx: Ctx<'_>, fetches: Vec<Fetch>, field_name: FetchField
         field_values.counts()
     };
 
-    let total_field_values: usize = field_value_counts.iter().map(|(_, n)| n).sum();
+    let total_field_values: usize = field_value_counts.values().sum();
 
     let top_ten_field_value_counts =
         field_value_counts.into_iter().sorted_by_key(|(_, cnt)| *cnt).rev().take(10);

--- a/crates/robbb_commands/src/commands/unban.rs
+++ b/crates/robbb_commands/src/commands/unban.rs
@@ -18,9 +18,9 @@ pub async fn unban(
     user_id: UserId,
 ) -> Res<()> {
     let guild = ctx.guild().context("Failed to load guild")?;
-    let user = user_id.to_user(&ctx.discord()).await?;
+    let user = user_id.to_user(&ctx.serenity_context()).await?;
 
-    guild.unban(&ctx.discord(), user_id).await?;
+    guild.unban(&ctx.serenity_context(), user_id).await?;
 
     ctx.say_success(format!("Succesfully deyote {}", user_id.mention())).await?;
 

--- a/crates/robbb_commands/src/lib.rs
+++ b/crates/robbb_commands/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::bool_to_int_with_if)]
 pub mod checks;
 pub mod commands;
 pub mod modlog;

--- a/crates/robbb_commands/src/modlog.rs
+++ b/crates/robbb_commands/src/modlog.rs
@@ -12,7 +12,7 @@ pub async fn log_note(ctx: Ctx<'_>, user: &User, note_content: &str) {
     let config = ctx.data().config.clone();
 
     config
-        .log_bot_action(ctx.discord(), |e| {
+        .log_bot_action(ctx.serenity_context(), |e| {
             e.title("Note");
             e.author_user(ctx.author());
             e.thumbnail(user.face());
@@ -34,7 +34,7 @@ pub async fn log_warn(
 ) {
     let config = ctx.get_config();
     config
-        .log_bot_action(ctx.discord(), |e| {
+        .log_bot_action(ctx.serenity_context(), |e| {
             e.title("Warn");
             e.author_user(ctx.author());
             e.thumbnail(user.face());
@@ -53,7 +53,7 @@ pub async fn log_warn(
 pub async fn log_kick(ctx: Ctx<'_>, context_msg: &Message, user: User, reason: &str) {
     let config = ctx.get_config();
     config
-        .log_bot_action(ctx.discord(), |e| {
+        .log_bot_action(ctx.serenity_context(), |e| {
             e.title("Kick");
             e.thumbnail(user.face());
             e.author_user(ctx.author());
@@ -71,7 +71,7 @@ pub async fn log_kick(ctx: Ctx<'_>, context_msg: &Message, user: User, reason: &
 pub async fn log_ban(ctx: Ctx<'_>, context_msg: &Message, successful_bans: &[User], reason: &str) {
     let config = ctx.get_config();
     config
-        .log_bot_action(ctx.discord(), |e| {
+        .log_bot_action(ctx.serenity_context(), |e| {
             e.title("Ban");
             e.author_user(ctx.author());
             e.description(format!(
@@ -87,7 +87,7 @@ pub async fn log_ban(ctx: Ctx<'_>, context_msg: &Message, successful_bans: &[Use
 pub async fn log_unban(ctx: Ctx<'_>, user: User) {
     let config = ctx.get_config();
     config
-        .log_bot_action(ctx.discord(), |e| {
+        .log_bot_action(ctx.serenity_context(), |e| {
             e.title("Unban");
             e.author_user(ctx.author());
             e.thumbnail(user.face());
@@ -111,7 +111,7 @@ pub async fn log_mute(
         .map(util::format_date_detailed);
 
     config
-        .log_bot_action(ctx.discord(), |e| {
+        .log_bot_action(ctx.serenity_context(), |e| {
             e.title("Mute");
             e.author_user(ctx.author());
             e.thumbnail(user.face());

--- a/crates/robbb_db/Cargo.toml
+++ b/crates/robbb_db/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serenity = { version = "0.11.2", default-features = false, features = ["collector", "builder", "cache", "chrono", "client", "gateway", "model", "http", "utils"]}
-poise = "0.2"
+serenity = { version = "0.11.5", default-features = false, features = ["collector", "builder", "cache", "chrono", "client", "gateway", "model", "http", "utils"]}
+poise = "0.5.2"
 thiserror = "1.0"
 sqlx = { version ="0.6", features = ["runtime-tokio-rustls", "sqlite", "chrono", "offline"] }
 anyhow = "1.0"

--- a/crates/robbb_db/src/db/highlights.rs
+++ b/crates/robbb_db/src/db/highlights.rs
@@ -57,7 +57,7 @@ impl HighlightsData {
         if user_list.is_empty() {
             self.entries.remove(&trigger.to_lowercase());
             self.combined_regex =
-                combine_multitrigger_regex(self.entries.iter().map(|(x, _)| x.as_str()))?;
+                combine_multitrigger_regex(self.entries.keys().map(|x| x.as_str()))?;
         }
         Ok(())
     }
@@ -72,7 +72,7 @@ impl HighlightsData {
             .or_insert_with(|| vec![user]);
         if !already_in_regex {
             self.combined_regex =
-                combine_multitrigger_regex(self.entries.iter().map(|(x, _)| x.as_str()))?;
+                combine_multitrigger_regex(self.entries.keys().map(|x| x.as_str()))?;
         }
         Ok(())
     }
@@ -88,7 +88,7 @@ impl HighlightsData {
         // update the regex if some words have been removed
         if self.entries.len() != old_length {
             self.combined_regex =
-                combine_multitrigger_regex(self.entries.iter().map(|(x, _)| x.as_str()))?;
+                combine_multitrigger_regex(self.entries.keys().map(|x| x.as_str()))?;
         }
         Ok(())
     }

--- a/crates/robbb_db/src/db/mod_action.rs
+++ b/crates/robbb_db/src/db/mod_action.rs
@@ -42,11 +42,17 @@ impl ModActionKind {
 
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, poise::ChoiceParameter)]
 pub enum ModActionType {
+    #[name = "Moderator Note"]
     ManualNote,
+    #[name = "[AUTO] - Blocklist Violation"]
     BlocklistViolation,
+    #[name = "Warning"]
     Warn,
+    #[name = "Mute"]
     Mute,
+    #[name = "Ban"]
     Ban,
+    #[name = "Kick"]
     Kick,
 }
 impl ModActionType {
@@ -70,19 +76,6 @@ impl ModActionType {
             ModActionType::Mute => 3,
             ModActionType::Ban => 4,
             ModActionType::Kick => 5,
-        }
-    }
-}
-
-impl std::fmt::Display for ModActionType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ModActionType::ManualNote => write!(f, "Moderator Note"),
-            ModActionType::BlocklistViolation => write!(f, "[AUTO] - Blocklist Violation"),
-            ModActionType::Warn => write!(f, "Warning"),
-            ModActionType::Mute => write!(f, "Mute"),
-            ModActionType::Ban => write!(f, "Ban"),
-            ModActionType::Kick => write!(f, "Kick"),
         }
     }
 }

--- a/crates/robbb_util/Cargo.toml
+++ b/crates/robbb_util/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serenity = { version = "0.11.2", default-features = false, features = ["collector", "builder", "cache", "chrono", "client", "gateway", "model", "http", "utils"]}
+serenity = { version = "0.11.5", default-features = false, features = ["collector", "builder", "cache", "chrono", "client", "gateway", "model", "http", "utils"]}
 anyhow = "1.0"
 serde_json = "1"
 serde = "1"
-poise = "0.2"
+poise = "0.5.2"
 thiserror = "1.0"
 lazy_static = "1.4"
 chrono = "0.4"

--- a/crates/robbb_util/src/collect_interaction.rs
+++ b/crates/robbb_util/src/collect_interaction.rs
@@ -51,6 +51,6 @@ pub fn await_component_interactions_by(
     by_user_limit: usize,
     timeout: std::time::Duration,
 ) -> UserSpecificComponentInteractionCollector {
-    let collector = message.await_component_interactions(&ctx).timeout(timeout).build();
+    let collector = message.await_component_interactions(ctx).timeout(timeout).build();
     UserSpecificComponentInteractionCollector { user_id, by_user_limit, inner_collector: collector }
 }

--- a/crates/robbb_util/src/embeds/paginated_embeds.rs
+++ b/crates/robbb_util/src/embeds/paginated_embeds.rs
@@ -77,7 +77,7 @@ impl PaginatedEmbed {
                 let created_msg = created_msg_handle.message().await?.into_owned();
 
                 tokio::spawn({
-                    let serenity_ctx = ctx.discord().clone();
+                    let serenity_ctx = ctx.serenity_context().clone();
                     let user_id = ctx.author().id;
                     let created_msg = created_msg.clone();
                     async move {

--- a/crates/robbb_util/src/extensions.rs
+++ b/crates/robbb_util/src/extensions.rs
@@ -59,7 +59,7 @@ pub impl<'a> Ctx<'a> {
     where
         F: FnOnce(&mut CreateEmbed) + Send + Sync,
     {
-        let embed = embeds::make_create_embed(self.discord(), |e| {
+        let embed = embeds::make_create_embed(self.serenity_context(), |e| {
             build(e);
             e
         })
@@ -67,8 +67,8 @@ pub impl<'a> Ctx<'a> {
         self.send(|f| {
             match self {
                 poise::Context::Application(_) => {}
-                poise::Context::Prefix(prefix) => {
-                    f.reference_message(prefix.msg);
+                poise::Context::Prefix(_) => {
+                    f.reply(true);
                 }
             }
             f.embed(|e| {
@@ -90,7 +90,8 @@ pub impl<'a> Ctx<'a> {
             msg.responding_to_user = %self.author().tag(),
             "Sending success message to user"
         );
-        let create_embed = embeds::make_success_embed(self.discord(), &text.to_string()).await;
+        let create_embed =
+            embeds::make_success_embed(self.serenity_context(), &text.to_string()).await;
         self.send_embed_full(true, |e| {
             e.clone_from(&create_embed);
         })
@@ -107,7 +108,8 @@ pub impl<'a> Ctx<'a> {
             msg.responding_to_user = %self.author().tag(),
             "Sending error message to user"
         );
-        let create_embed = embeds::make_error_embed(self.discord(), &text.to_string()).await;
+        let create_embed =
+            embeds::make_error_embed(self.serenity_context(), &text.to_string()).await;
         self.send_embed_full(true, |e| {
             e.clone_from(&create_embed);
         })
@@ -124,7 +126,7 @@ pub impl<'a> Ctx<'a> {
             "Sending success_mod_action message to user"
         );
         let create_embed =
-            embeds::make_success_mod_action_embed(self.discord(), &text.to_string()).await;
+            embeds::make_success_mod_action_embed(self.serenity_context(), &text.to_string()).await;
         self.send_embed(|e| {
             e.clone_from(&create_embed);
         })
@@ -134,7 +136,7 @@ pub impl<'a> Ctx<'a> {
     async fn guild_channel(&self) -> anyhow::Result<GuildChannel> {
         Ok(self
             .channel_id()
-            .to_channel(&self.discord())
+            .to_channel(&self.serenity_context())
             .await
             .context("Failed to load channel")?
             .guild()

--- a/crates/robbb_util/src/modal.rs
+++ b/crates/robbb_util/src/modal.rs
@@ -12,11 +12,11 @@ async fn wait_for_modal_ir_response<T: poise::Modal>(ctx: AppCtx<'_>, user_id: U
     ctx.has_sent_initial_response.store(true, std::sync::atomic::Ordering::SeqCst);
     // Wait for user to submit
     let response =
-        CollectModalInteraction::new(&ctx.discord.shard).author_id(user_id).await.unwrap();
+        CollectModalInteraction::new(ctx.serenity_context()).author_id(user_id).await.unwrap();
 
     // Send acknowledgement so that the pop-up is closed
     response
-        .create_interaction_response(ctx.discord, |b| {
+        .create_interaction_response(ctx.serenity_context(), |b| {
             b.kind(InteractionResponseType::DeferredUpdateMessage)
         })
         .await?;
@@ -30,8 +30,8 @@ pub async fn create_modal_component_ir<T: poise::Modal>(
     defaults: Option<T>,
 ) -> Res<T> {
     interaction
-        .create_interaction_response(&ctx.discord, |ir| {
-            *ir = T::create(defaults);
+        .create_interaction_response(&ctx.serenity_context(), |ir| {
+            *ir = T::create(defaults, String::new());
             ir
         })
         .await?;
@@ -44,8 +44,8 @@ pub async fn create_modal_command_ir<T: poise::Modal>(
     defaults: Option<T>,
 ) -> Res<T> {
     interaction
-        .create_interaction_response(&ctx.discord, |ir| {
-            *ir = T::create(defaults);
+        .create_interaction_response(&ctx.serenity_context(), |ir| {
+            *ir = T::create(defaults, String::new());
             ir
         })
         .await?;


### PR DESCRIPTION
This PR updates poise and serenity,
and then fixes the currently broken /ask command:
Discord suddenly started _enforcing the modal constraints on the default values_.
This is the stupidest design decision I have ever seen, as
it now basically means the easiest way to satisfy the minimum length requirement
for a question is to do nothing and to post `<Summarize your question>` as the message title...
  but discord be discord, whatever..
