### PR TITLE
Ensure at least one actual moderator is pinged

### DIFF
--- a/crates/robbb_commands/src/commands/modping.rs
+++ b/crates/robbb_commands/src/commands/modping.rs
@@ -14,7 +14,7 @@ pub async fn modping(
     let config = ctx.get_config();
     let guild = ctx.guild().user_error("not in a guild")?.to_owned();
 
-    let mods_and_helpers = guild
+    let online_staff = guild
         .members_with_status(Online)
         .chain(guild.members_with_status(Idle))
         .chain(guild.members_with_status(DoNotDisturb))
@@ -23,21 +23,20 @@ pub async fn modping(
         })
         .collect_vec();
 
-    let contains_moderators = mods_and_helpers
-        .iter()
-        .any(|member| member.roles.contains(&config.role_mod));
+    let contains_moderators =
+        online_staff.iter().any(|member| member.roles.contains(&config.role_mod));
 
-    let mods = if mods_and_helpers.len() < 2 || !contains_moderators {
-        // ping moderator role if no helpers and moderators, or no moderators at all are online
-        config.role_mod.mention().to_string()
+    let staff_to_ping = if contains_moderators {
+        online_staff.iter().map(|m| m.mention()).join(", ")
     } else {
-        mods_and_helpers.iter().map(|m| m.mention()).join(", ")
+        config.role_mod.mention().to_string()
+            + &online_staff.iter().map(|m| m.mention()).join(", ")
     };
 
-    ctx.send(
-        CreateReply::default()
-            .content(format!("{} pinged staff {mods} for reason {reason}", ctx.author().mention())),
-    )
+    ctx.send(CreateReply::default().content(format!(
+        "{} pinged staff {staff_to_ping} for reason {reason}",
+        ctx.author().mention()
+    )))
     .await?;
 
     Ok(())

--- a/crates/robbb_commands/src/commands/modping.rs
+++ b/crates/robbb_commands/src/commands/modping.rs
@@ -29,8 +29,7 @@ pub async fn modping(
     let staff_to_ping = if contains_moderators {
         online_staff.iter().map(|m| m.mention()).join(", ")
     } else {
-        config.role_mod.mention().to_string()
-            + &online_staff.iter().map(|m| m.mention()).join(", ")
+        config.role_mod.mention().to_string() + &online_staff.iter().map(|m| m.mention()).join(", ")
     };
 
     ctx.send(CreateReply::default().content(format!(

--- a/crates/robbb_commands/src/commands/modping.rs
+++ b/crates/robbb_commands/src/commands/modping.rs
@@ -23,8 +23,12 @@ pub async fn modping(
         })
         .collect_vec();
 
-    let mods = if mods_and_helpers.len() < 2 {
-        // ping moderator role if no helpers nor mods are available
+    let contains_moderators = mods_and_helpers
+        .iter()
+        .any(|member| member.roles.contains(&config.role_mod));
+
+    let mods = if mods_and_helpers.len() < 2 || !contains_moderators {
+        // ping moderator role if no helpers and moderators, or no moderators at all are online
         config.role_mod.mention().to_string()
     } else {
         mods_and_helpers.iter().map(|m| m.mention()).join(", ")


### PR DESCRIPTION
/modping is used when immediate moderation is required, but moderators currently tend to make themselves unavailable, so the bot only pings helpers.

This change ensures that at least one moderator is pinged by pinging all online moderators, or all moderators in case none are online, and also pinging all online helpers.

This change is not tested, since I have no testing discord, but the change is quite simple.

Please review, test and merge @elkowar 